### PR TITLE
Add error handling in case of AutocompleteStub Failure for DLIS-5819 …

### DIFF
--- a/src/stub_launcher.cc
+++ b/src/stub_launcher.cc
@@ -787,7 +787,11 @@ StubLauncher::WaitForStubProcess()
   CloseHandle(stub_pid_.hThread);
 #else
   int status;
-  waitpid(stub_pid_, &status, 0);
+  if (stub_pid_ != 0) {
+    // Added this check to ensure server doesn't hang waiting after stub
+    // process has already be killed and cannot be waited on
+    waitpid(stub_pid_, &status, 0);
+  }
 #endif
 }
 


### PR DESCRIPTION
…(#356) (#357)

* DLIS-5819
* Guard WaitForStubProcess in case of failed auto-complete-config